### PR TITLE
fix: read "this file" history on startup and refresh on view change

### DIFF
--- a/src/core/events.ts
+++ b/src/core/events.ts
@@ -164,6 +164,8 @@ export async function handleFileOpen(file: TFile) {
 
 	if (entry) state.setCurrentActivity(entry);
 	state.isUpdatingActivity = false;
+
+	state.emit(EVENTS.REFRESH_EVERYTHING);
 }
 
 /**

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -225,6 +225,18 @@ export async function getCurrentCount(
 		if (state.currentActivity) {
 			return sumTimeEntries(state?.currentActivity, unit) || 0;
 		} else {
+			// No current session - just sum all past activity for this file
+			const activeFile = state.plugin.app.workspace.getActiveFile();
+			if (activeFile) {
+				const activities = await db.dailyActivity
+					.where("filePath")
+					.equals(activeFile.path)
+					.toArray();
+				console.log(activities);
+				return activities.reduce((sum, activity) => {
+					return sum + sumTimeEntries(activity, unit, false);
+				}, 0);
+			}
 			return 0;
 		}
 	}


### PR DESCRIPTION
On startup, fix the issue of "this file" reading 0 words/chars due to no `currentActivity`. Instead, read from past activity of the current active file. Likewise, when changing views, refresh everything to show a current state of active file instead of the stale previously active file.