### PR TITLE
feat: Add option to exclude deleted words

### DIFF
--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -55,7 +55,14 @@ const context = await esbuild.context({
 });
 
 if (prod) {
-	await context.rebuild();
+	console.log("Starting production build...");
+	try {
+		const result = await context.rebuild();
+		console.log("Build complete.");
+		// console.log(result);
+	} catch (e) {
+		console.error("Build failed:", e);
+	}
 	process.exit(0);
 } else {
 	await context.watch(); // Watch for file changes in dev mode

--- a/src/core/events.ts
+++ b/src/core/events.ts
@@ -95,6 +95,29 @@ export async function handleEditorChange(
 	 * Time keys are added in blocks of 5 minutes and snap to the nearest time
 	 */
 
+	/* -------------------------------------------------------------------------- */
+	/*                        SIMPLE DELTA TRACKING                               */
+	/* -------------------------------------------------------------------------- */
+
+	let waDelta = 0;
+	let wdDelta = 0;
+	let caDelta = 0;
+	let cdDelta = 0;
+
+	// WORD CALCULATION
+	if (wordsAdded > 0) {
+		waDelta = wordsAdded;
+	} else if (wordsAdded < 0) {
+		wdDelta = -wordsAdded;
+	}
+
+	// CHAR CALCULATION
+	if (charsAdded > 0) {
+		caDelta = charsAdded;
+	} else if (charsAdded < 0) {
+		cdDelta = -charsAdded;
+	}
+
 	const existingEntry = changes.find(
 		(entry) => entry.timeKey === currentTimeKey,
 	);
@@ -105,11 +128,19 @@ export async function handleEditorChange(
 			timeKey: currentTimeKey,
 			w: wordsAdded || 0,
 			c: charsAdded || 0,
+			wa: waDelta,
+			wd: wdDelta,
+			ca: caDelta,
+			cd: cdDelta,
 		});
 	} else {
 		// Entry exists, so update the word and char count
 		existingEntry.w += wordsAdded;
 		existingEntry.c += charsAdded;
+		existingEntry.wa = (existingEntry.wa || 0) + waDelta;
+		existingEntry.wd = (existingEntry.wd || 0) + wdDelta;
+		existingEntry.ca = (existingEntry.ca || 0) + caDelta;
+		existingEntry.cd = (existingEntry.cd || 0) + cdDelta;
 	}
 
 	// WORKING ON UPDATING JUST TODAY!!!
@@ -204,6 +235,10 @@ async function flushChangesToDB(activity: DailyActivity) {
 				if (mergedMap[entry.timeKey]) {
 					mergedMap[entry.timeKey].w = entry.w;
 					mergedMap[entry.timeKey].c = entry.c;
+					mergedMap[entry.timeKey].wa = entry.wa;
+					mergedMap[entry.timeKey].wd = entry.wd;
+					mergedMap[entry.timeKey].ca = entry.ca;
+					mergedMap[entry.timeKey].cd = entry.cd;
 				} else {
 					mergedMap[entry.timeKey] = { ...entry };
 				}
@@ -265,60 +300,80 @@ export async function handleFileDelete(file: TFile) {
 			.dailyActivity.where("[date+filePath]")
 			.equals([state.today, file.path])
 			.modify((dailyEntry) => {
-				let wordSum = 0;
-				let charSum = 0;
-
 				const currentTimeKey =
 					floorMomentToFive(moment()).format("HH:mm");
+				const changes = dailyEntry.changes || [];
+				if (!dailyEntry.changes) dailyEntry.changes = changes;
 
-				/** If no changed was made to the file
-				 *  Then the delta is just the word count when it was opened
-				 */
+				/* -------------------------------------------------------------------------- */
+				/*                            CALCULATE CURRENT TOTAL                         */
+				/* -------------------------------------------------------------------------- */
 
-				if (!dailyEntry.changes || dailyEntry.changes?.length == 0) {
-					dailyEntry.changes.push({
-						timeKey: currentTimeKey,
-						w: -dailyEntry.wordCountStart,
-						c: -dailyEntry.charCountStart,
-					});
-					return;
+				let totalWords = dailyEntry.wordCountStart;
+				let totalChars = dailyEntry.charCountStart;
+				let currentDailyWA = 0;
+				let currentDailyCA = 0;
+
+				for (const change of changes) {
+					totalWords += change.w;
+					totalChars += change.c;
+					currentDailyWA += change.wa || 0;
+					currentDailyCA += change.ca || 0;
 				}
 
-				/** If there where changes made,
-				 *  We need to sum those changes
-				 *  The last change is only included if it's timekey isn't the current one
-				 */
-				// Get the last change (if any)
-				const lastEntry =
-					dailyEntry.changes[dailyEntry.changes.length - 1];
-				const lastTimeKey = lastEntry?.timeKey;
+				// The delta needed to reach 0
+				const wordsAdded = -totalWords;
+				const charsAdded = -totalChars;
 
-				for (let i = 0; i < dailyEntry.changes.length - 1; i++) {
-					wordSum += dailyEntry.changes[i].w;
-					charSum += dailyEntry.changes[i].c;
+				/* -------------------------------------------------------------------------- */
+				/*                        SIMPLE DELTA TRACKING                               */
+				/* -------------------------------------------------------------------------- */
+
+				let waDelta = 0;
+				let wdDelta = 0;
+				let caDelta = 0;
+				let cdDelta = 0;
+
+				// WORD CALCULATION
+				if (wordsAdded > 0) {
+					waDelta = wordsAdded;
+				} else if (wordsAdded < 0) {
+					wdDelta = -wordsAdded;
 				}
 
-				// If lastTimeKey is not the same as current, include it
-				if (lastEntry && lastTimeKey !== currentTimeKey) {
-					wordSum += lastEntry.w;
-					charSum += lastEntry.c;
+				// CHAR CALCULATION
+				if (charsAdded > 0) {
+					caDelta = charsAdded;
+				} else if (charsAdded < 0) {
+					cdDelta = -charsAdded;
 				}
 
 				const newEntry: TimeEntry = {
 					timeKey: currentTimeKey,
-					w: -(wordSum + dailyEntry.wordCountStart),
-					c: -(charSum + dailyEntry.charCountStart),
+					w: wordsAdded,
+					c: charsAdded,
+					wa: waDelta,
+					wd: wdDelta,
+					ca: caDelta,
+					cd: cdDelta,
 				};
 
 				// Find and update the existing entry if it exists
-				const existingIndex = dailyEntry.changes.findIndex(
+				const existingIndex = changes.findIndex(
 					(e) => e.timeKey === currentTimeKey,
 				);
 
 				if (existingIndex !== -1) {
-					dailyEntry.changes[existingIndex] = newEntry;
+
+					const e = changes[existingIndex];
+					e.w += wordsAdded;
+					e.c += charsAdded;
+					e.wa = (e.wa || 0) + waDelta;
+					e.wd = (e.wd || 0) + wdDelta;
+					e.ca = (e.ca || 0) + caDelta;
+					e.cd = (e.cd || 0) + cdDelta;
 				} else {
-					dailyEntry.changes.push(newEntry);
+					changes.push(newEntry);
 				}
 			});
 
@@ -332,7 +387,7 @@ export async function handleFileDelete(file: TFile) {
  * @function handleFileCreate
  * - Add file to FileStats table?
  */
-export function handleFileCreate(file: TFile) {}
+export function handleFileCreate(file: TFile) { }
 
 /**
  * @function handleFileRename

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -1,6 +1,6 @@
 import { getDateStreaks } from "@/utils/utils";
 import { getDB } from "./db";
-import { Language, Unit, TargetCount, CalculationType } from "../defs/types";
+import { Language, Unit, TargetCount, CalculationType, NegativeWordCountMode } from "../defs/types";
 import { formatDate } from "@/utils/dateUtils";
 import { EVENTS, state } from "@/core/pluginState";
 import {
@@ -8,7 +8,7 @@ import {
 	getStartOfWeek,
 	getStartOfYear,
 } from "@/utils/dateUtils";
-import { sumTimeEntries } from "@/utils/utils";
+import { sumTimeEntries, sumTimeEntriesWithMode } from "@/utils/utils";
 import { DailyActivity } from "./types";
 import { moment as _moment, debounce, Notice, Vault } from "obsidian";
 import { getFileWordAndCharCount } from "@/utils/utils";
@@ -289,7 +289,7 @@ export async function getCurrentCount(
 				Math.floor(
 					(new Date(state.today).getTime() -
 						new Date(startDate).getTime()) /
-						(1000 * 3600 * 24),
+					(1000 * 3600 * 24),
 				) + 1;
 			break;
 
@@ -361,3 +361,137 @@ export const deleteActivityFromDate = async (
 		);
 	}
 };
+
+export async function getTotalValueByDateWithMode(
+	date: string,
+	unit: Unit,
+	mode: NegativeWordCountMode
+): Promise<number> {
+	const activities = await getDB()
+		.dailyActivity.where("date")
+		.equals(date)
+		.toArray();
+
+	if (mode === NegativeWordCountMode.NET) {
+		let value = activities.reduce((sum, activity) => {
+			return sum + sumTimeEntries(activity, unit, true);
+		}, 0);
+		return value ?? 0;
+	} else {
+		// For Gross we need to sum individually
+		let totalAdded = 0;
+
+		for (const activity of activities) {
+			// mode will be GROSS
+			const res = sumTimeEntriesWithMode(activity, unit, NegativeWordCountMode.GROSS, true);
+			if (typeof res === 'number') {
+				totalAdded += res;
+			}
+		}
+
+		return totalAdded;
+	}
+}
+
+export async function getCurrentCountWithMode(
+	unit: Unit,
+	target: TargetCount,
+	calc: CalculationType = CalculationType.TOTAL,
+	mode: NegativeWordCountMode = NegativeWordCountMode.NET
+): Promise<number | string> {
+	if (target === TargetCount.CURRENT_FILE) {
+		if (state.currentActivity) {
+			return sumTimeEntriesWithMode(state?.currentActivity, unit, mode) || 0;
+		} else {
+			const activeFile = state.plugin.app.workspace.getActiveFile();
+			if (activeFile) {
+				const activities = await getDB()
+					.dailyActivity.where("filePath")
+					.equals(activeFile.path)
+					.toArray();
+
+				if (mode === NegativeWordCountMode.NET) {
+					return activities.reduce((sum, activity) => {
+						return sum + sumTimeEntries(activity, unit, false);
+					}, 0);
+				} else {
+					// Aggregate Gross
+					let totalAdded = 0;
+					for (const activity of activities) {
+						// mode is GROSS
+						const res = sumTimeEntriesWithMode(activity, unit, NegativeWordCountMode.GROSS, false);
+						if (typeof res === 'number') {
+							totalAdded += res;
+						}
+					}
+					return totalAdded;
+				}
+			}
+			return 0;
+		}
+	}
+
+	if (target === TargetCount.CURRENT_DAY) {
+		return await getTotalValueByDateWithMode(state.today, unit, mode);
+	}
+
+
+	// If mode is NET, just use old function
+	if (mode === NegativeWordCountMode.NET) {
+		return getCurrentCount(unit, target, calc);
+	}
+
+	// GROSS mode support for ranges
+	if (mode === NegativeWordCountMode.GROSS) {
+		let startDate: string;
+		let endDate = state.today;
+
+		switch (target) {
+			case TargetCount.CURRENT_WEEK:
+				startDate = formatDate(getStartOfWeek(new Date()));
+				break;
+			case TargetCount.CURRENT_MONTH:
+				startDate = formatDate(getStartOfMonth(new Date()));
+				break;
+			case TargetCount.CURRENT_YEAR:
+				startDate = formatDate(getStartOfYear(new Date()));
+				break;
+			case TargetCount.LAST_DAY:
+				// Last 24h is special
+				return getCurrentCount(unit, target, calc); // Fallback for last 24h to Net for now
+			case TargetCount.LAST_WEEK:
+				startDate = moment(state.today).subtract(7, "days").format("YYYY-MM-DD");
+				break;
+			case TargetCount.LAST_MONTH:
+				startDate = moment(state.today).subtract(30, "days").format("YYYY-MM-DD");
+				break;
+			case TargetCount.LAST_YEAR:
+				startDate = moment(state.today).subtract(365, "days").format("YYYY-MM-DD");
+				break;
+			default:
+				return getCurrentCount(unit, target, calc);
+		}
+
+		// Fetch all activities in range and sum added
+		const activities = await getDB()
+			.dailyActivity.where("date")
+			.between(startDate, endDate, true, true)
+			.toArray();
+
+		let totalAdded = 0;
+		activities.forEach(act => {
+			const res = sumTimeEntriesWithMode(act, unit, NegativeWordCountMode.GROSS, true);
+			if (typeof res === 'number') totalAdded += res;
+		});
+
+		// Average calculation
+		if (calc === CalculationType.AVG) {
+			const totalDays = moment(endDate).diff(startDate, 'days') + 1;
+			return Math.round(totalAdded / totalDays);
+		}
+
+		return totalAdded;
+	}
+
+	return getCurrentCount(unit, target, calc);
+}

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -11,4 +11,8 @@ export interface TimeEntry {
 	timeKey: string;
 	w: number;
 	c: number;
+	wa?: number;
+	wd?: number;
+	ca?: number;
+	cd?: number;
 }

--- a/src/defs/types.ts
+++ b/src/defs/types.ts
@@ -63,6 +63,11 @@ export enum HeatmapColorModes {
 	LIQUID = "liquid",
 }
 
+export enum NegativeWordCountMode {
+	NET = "net",
+	GROSS = "gross",
+}
+
 export interface Settings {
 	dailyWritingGoal: number; // created as setting, not used anywhere yet
 	enabledLanguages: Language[]; // guides the definition of REGEXes for word counting
@@ -70,6 +75,7 @@ export interface Settings {
 	startOfTheWeek: "MONDAY" | "SUNDAY"; // not used yet, should be used to offset start of the week calculations and heatmap
 	heatmapConfig: HeatmapConfig;
 	heatmapNavigation: boolean;
+	negativeWordCountMode: NegativeWordCountMode;
 	sidebarConfig: {
 		visibility: {
 			showSlots: boolean;
@@ -133,6 +139,7 @@ export const DEFAULT_SETTINGS: Settings = {
 	dailyWritingGoal: 500,
 	startOfTheWeek: "SUNDAY",
 	heatmapNavigation: true,
+	negativeWordCountMode: NegativeWordCountMode.NET,
 	heatmapConfig: {
 		roundCells: true,
 		hideMonthLabels: false,

--- a/src/ui/components/Slot.tsx
+++ b/src/ui/components/Slot.tsx
@@ -4,7 +4,7 @@ import { setIcon } from "obsidian";
 import { useState, useEffect, useRef } from "react";
 import * as RadixTooltip from "@radix-ui/react-tooltip";
 
-import { getCurrentCount } from "@/db/queries";
+import { getCurrentCount, getCurrentCountWithMode } from "@/db/queries";
 import { CalculationType } from "@/defs/types";
 import { Tooltip } from "./Tooltip";
 import { getSlotLabel, weekdaysNames } from "../texts";
@@ -121,11 +121,16 @@ export const Slot = ({
 		)
 			setIsLoading(true);
 		try {
-			const v = await getCurrentCount(unitType, optionType, calcMode);
+			// const v = await getCurrentCount(unitType, optionType, calcMode);
+			const v = await getCurrentCountWithMode(
+				unitType,
+				optionType,
+				calcMode,
+				plugin.data.settings.negativeWordCountMode
+			);
 			if (optionType === TargetCount.CURRENT_DAY) {
-				const newProgress =
-					(v / state.plugin.data.settings.dailyWritingGoal) * 100;
-
+				const goal = state.plugin.data.settings.dailyWritingGoal;
+				const newProgress = ((v as number) / goal) * 100;
 				setProgressValue(Math.min(newProgress, 100));
 			}
 			setValue(v);

--- a/src/ui/views/SettingsTab.ts
+++ b/src/ui/views/SettingsTab.ts
@@ -5,6 +5,7 @@ import {
 	DEFAULT_SETTINGS,
 	Language,
 	HeatmapColorModes,
+	NegativeWordCountMode,
 } from "@/defs/types";
 import { state } from "@/core/pluginState";
 
@@ -24,7 +25,7 @@ class ConfirmationModal extends Modal {
 		super(app);
 		this.message = message;
 		this.onConfirm = onConfirm;
-		this.onCancel = onCancel || (() => {});
+		this.onCancel = onCancel || (() => { });
 		this.confirmText = confirmText;
 	}
 
@@ -230,7 +231,26 @@ export class SettingsTab extends PluginSettingTab {
 						this.plugin.data.settings.dailyWritingGoal = value;
 						this.plugin.updateAndSaveEverything();
 					}),
+
 			);
+
+		new Setting(containerEl)
+			.setName("Negative Word Count Mode")
+			.setDesc("Choose how deletions affect your daily stats.")
+			.addDropdown((dropdown) => {
+				dropdown
+					.addOption(NegativeWordCountMode.NET, "Net (Additions - Deletions)")
+					.addOption(NegativeWordCountMode.GROSS, "Gross (Additions Only)")
+					.setValue(
+						this.plugin.data.settings.negativeWordCountMode ||
+						NegativeWordCountMode.NET,
+					)
+					.onChange(async (value) => {
+						this.plugin.data.settings.negativeWordCountMode =
+							value as NegativeWordCountMode;
+						this.plugin.updateAndSaveEverything();
+					});
+			});
 
 		new Setting(containerEl)
 			.setName("Heatmap navigation")
@@ -459,11 +479,11 @@ export class SettingsTab extends PluginSettingTab {
 					`Are you sure you want to reset the ${theme} theme colors to their default values?`,
 					async () => {
 						this.plugin.data.settings.heatmapConfig.colors[theme] =
-							{
-								...DEFAULT_SETTINGS.heatmapConfig.colors![
-									theme
-								],
-							};
+						{
+							...DEFAULT_SETTINGS.heatmapConfig.colors![
+							theme
+							],
+						};
 						await this.plugin.updateAndSaveEverything();
 						this.plugin.applyColorStyles();
 						this.display();
@@ -552,4 +572,4 @@ export class SettingsTab extends PluginSettingTab {
 	}
 }
 
-export {};
+export { };

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,4 +1,4 @@
-import { HeatmapColorModes } from "../defs/types";
+import { HeatmapColorModes, NegativeWordCountMode } from "../defs/types";
 import { CalculationType, TargetCount } from "../defs/types";
 import { DailyActivity, TimeEntry } from "@/db/types";
 import { App } from "obsidian";
@@ -85,9 +85,7 @@ export const getDayIndex = (dayIndex: number): number => {
 	return dayIndex === 0 ? 6 : dayIndex - 1;
 };
 
-// function getRandomArbitrary(min, max) {
-// 	return Math.random() * (max - min) + min;
-// }
+
 
 export function getRandomInt(min: number, max: number) {
 	const minCeiled = Math.ceil(min);
@@ -150,6 +148,68 @@ export function sumTimeEntries(
 	}
 
 	return total;
+}
+
+export function sumTimeEntriesWithMode(
+	dailyActivity: DailyActivity,
+	unit: Unit,
+	mode: NegativeWordCountMode = NegativeWordCountMode.NET,
+	excludeStart?: boolean,
+): number {
+	let totalNet = 0;
+	let totalAdded = 0;
+	let totalDeleted = 0;
+
+	// Add start counts (legacy/net)
+	const startCount = (unit === Unit.WORD ? dailyActivity?.wordCountStart : dailyActivity?.charCountStart) || 0;
+	if (!excludeStart) {
+		totalNet += startCount;
+		totalAdded += startCount; // Assume start count is all "added" historically
+	}
+
+	if (dailyActivity?.changes) {
+		for (const entry of dailyActivity.changes) {
+			const w = entry.w || 0;
+			const c = entry.c || 0;
+			const wa = entry.wa ?? (w > 0 ? w : 0); // Fallback for old entries
+			const wd = entry.wd ?? (w < 0 ? -w : 0); // Fallback for old entries
+			const ca = entry.ca ?? (c > 0 ? c : 0);
+			const cd = entry.cd ?? (c < 0 ? -c : 0);
+
+			if (unit === Unit.WORD) {
+				totalNet += w;
+				totalAdded += wa;
+				totalDeleted += wd;
+			} else {
+				totalNet += c;
+				totalAdded += ca;
+				totalDeleted += cd;
+			}
+		}
+	}
+
+	if (mode === NegativeWordCountMode.GROSS) {
+		return totalAdded;
+	} else {
+		return totalNet;
+	}
+}
+
+export function sumAddedDeleted(dailyActivity: DailyActivity) {
+	let wa = 0;
+	let wd = 0;
+	let ca = 0;
+	let cd = 0;
+
+	if (dailyActivity?.changes) {
+		for (const entry of dailyActivity.changes) {
+			wa += entry.wa || 0;
+			wd += entry.wd || 0;
+			ca += entry.ca || 0;
+			cd += entry.cd || 0;
+		}
+	}
+	return { wa, wd, ca, cd };
 }
 
 async function resetDatabase() {

--- a/src/utils/windowUtility.ts
+++ b/src/utils/windowUtility.ts
@@ -1,5 +1,5 @@
 export function getCorePluginSettings(pluginId: string) {
-	const plugin = window.app.internalPlugins.getPluginById(pluginId);
+	const plugin = (window as any).app.internalPlugins.getPluginById(pluginId);
 	if (plugin?.enabled) {
 		return plugin.instance?.options;
 	}


### PR DESCRIPTION
I’ve been writing with this plugin, and negative word count bothers me sometimes, since I refactor my stories quite often.
 #87 I noticed this seems to be a common issue. So I tried to add a separate mode to exclude deletions. It works fine on my end. I hope this could help solve some people's problems.
 
#### What's changed:

1. Optionally, data model can store addition and deletion word/character separately, backward compatible.
2. Added a "Negative Word Count Mode" switch in the settings panel.
3. Net Mode (Default): Keeps the existing behavior (Additions - Deletions), allowing word counts.
4. Gross Mode: Ignores deletions, counting only additions.

#### Possible future word count improvement:

Gross mode is essentially a compromise; it strictly counts all additions. This means that if you delete a paragraph and paste it back, those words will be counted twice.
To make word count truly accurate, a more sophisticated solution would be to add a new periodic routine that calculates word count for each day, using a diff-based algorithm to distinguish true new content from old snapshots, then correct the existing live word counts.
However, it's costly and much harder to implement, but I hope someday we can do it.


