### PR TITLE
feat: add Include/Exclude directory filtering for the sidebar and code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ Embed customizable heatmaps with filtering and display options:
 ```js
 filePath starts_with "journal"
 
+INCLUDE journal, projects                  // optional, same syntax as Directory Filtering below
+EXCLUDE journal/drafts                     // optional, takes priority over INCLUDE
+
 OPTIONS                                    // must always start with the OPTIONS header
 HIDE month_labels, weekday_labels          // allows to hide the labels
 COLORING_MODE liquid                       // toggles the coloring mode (liquid, stops, solid or gradual)
@@ -113,6 +116,13 @@ Available Options:
 - `STOPS`: Define threshold values (e.g., `100, 500, 1000`)
 - `SQUARED_CELLS` or `ROUNDED_CELLS`: Control cell appearance
 
+**Directory Filtering**:
+
+- `INCLUDE folder_a, folder_b`: only count files under these directories
+- `EXCLUDE folder_a, folder_b`: never count files under these directories (takes priority over `INCLUDE`)
+- Both are optional and comma-separated, and combine with the `filePath` query above rather than replacing it. Use `*` as a wildcard within a folder name, e.g. `*journal` matches both `journal/` and `myjournal/`. Matching is **case-sensitive** — `journal` will not match a folder named `Journal`. See [Directory Filtering](#directory-filtering) below for the full matching rules.
+- This filter is independent from the sidebar's Include/Exclude Directories setting — it does not inherit it, and only applies within this code block.
+
 #### Data Slots (`ktr-slots`)
 
 Display inline statistics with customizable metrics:
@@ -124,6 +134,9 @@ CURRENT_STREAK
 WHOLE_VAULT
 CURRENT_MONTH, WORDS, AVG
 CURRENT_YEAR
+
+INCLUDE journal, projects
+EXCLUDE journal/drafts
 ```
 
 Available Slots:
@@ -145,6 +158,14 @@ Available Slots:
 - Specify WORDS or CHARS for the count unit
 - Add AVG for average calculations where applicable
 
+**Directory Filtering**:
+
+- `INCLUDE folder_a, folder_b`: only count files under these directories
+- `EXCLUDE folder_a, folder_b`: never count files under these directories (takes priority over `INCLUDE`)
+- Both are optional and comma-separated. Use `*` as a wildcard within a folder name, e.g. `*journal` matches both `journal/` and `myjournal/`. Matching is **case-sensitive** — `journal` will not match a folder named `Journal`. See [Directory Filtering](#directory-filtering) below for the full matching rules.
+- `CURRENT_FILE`, `CURRENT_STREAK`, and `WHOLE_VAULT` always ignore this filter, since they're not scoped to a date range of file activity.
+- This filter is independent from the sidebar's Include/Exclude Directories setting — it does not inherit it, and only applies within this code block.
+
 #### Daily Entries (`ktr-entries`)
 
 Display writing activity for specific dates:
@@ -162,6 +183,29 @@ Access comprehensive customization options through the plugin settings:
 - Set daily writing goals and track streaks
 - Configure heatmap appearance (coloring, cell shapes, labels)
 - Toggle visibility of different plugin components
+- Scope the sidebar to specific directories with Include/Exclude Directories (see below)
+
+### Directory Filtering
+
+The Sidebar settings section has two optional fields:
+
+- **Include Directories**: comma-separated list of directories to scope the sidebar's heatmap, slots, and entries to (e.g. `journal, projects`)
+- **Exclude Directories**: comma-separated list of directories to exclude, same syntax, takes priority over Include Directories
+
+Both are optional — leaving them empty keeps the current behavior of tracking your entire vault. A pattern matches a folder name segment by segment from the root of your vault, and `*` can be used as a wildcard within a segment:
+
+| Pattern       | Matches                          | Doesn't match                    |
+| ------------- | --------------------------------- | --------------------------------- |
+| `journal`     | `journal/note.md`                 | `myjournal/note.md`, `journal2/note.md` |
+| `*journal`    | `journal/note.md`, `myjournal/note.md` | `journal2/note.md`           |
+| `journal*`    | `journal/note.md`, `journal2/note.md` | `myjournal/note.md`           |
+| `proj*/2024`  | `proj-alpha/2024/note.md`         | `proj-alpha/2023/note.md`         |
+
+Matching is **case-sensitive**: `journal` will not match a folder named `Journal`. If your vault mixes casing for the same folder, list every variant you want covered (e.g. `journal, Journal`).
+
+This setting only affects the plugin's **sidebar panel**. Code blocks embedded in notes (`ktr-heatmap`, `ktr-slots`, `ktr-entries`) are unaffected by it and keep using their own filter syntax — `ktr-heatmap` and `ktr-slots` both support the same Include/Exclude directory syntax via `INCLUDE`/`EXCLUDE` lines (see above), while `ktr-entries` uses the `filePath` query syntax described in its section.
+
+`WHOLE_VAULT` and `CURRENT_STREAK` always reflect the entire vault regardless of this filter, and `CURRENT_FILE` always reflects whichever file is currently open.
 
 ## Data and Privacy
 

--- a/src/core/codeBlocks.ts
+++ b/src/core/codeBlocks.ts
@@ -8,6 +8,38 @@ import { createRoot } from "react-dom/client";
 import React from "react";
 import { Heatmap } from "@/ui/components/Heatmap";
 import { MarkdownRenderChild } from "obsidian";
+import { parseDirectoryList } from "@/utils/utils";
+import { DirectoryFilter } from "@/defs/types";
+
+function extractDirectoryDirectives(source: string): {
+	remainingLines: string;
+	directoryFilter: DirectoryFilter;
+} {
+	const lines = source.split("\n");
+	const remainingLines: string[] = [];
+	let include: string[] = [];
+	let exclude: string[] = [];
+
+	for (const rawLine of lines) {
+		const line = rawLine.trim();
+
+		const includeMatch = line.match(/^INCLUDE\s+(.+)$/);
+		const excludeMatch = line.match(/^EXCLUDE\s+(.+)$/);
+
+		if (includeMatch) {
+			include = parseDirectoryList(includeMatch[1]);
+		} else if (excludeMatch) {
+			exclude = parseDirectoryList(excludeMatch[1]);
+		} else {
+			remainingLines.push(rawLine);
+		}
+	}
+
+	return {
+		remainingLines: remainingLines.join("\n"),
+		directoryFilter: { include, exclude },
+	};
+}
 
 ///////////// HEATMAP
 // Previously returned a new function for each code block, now directly processes the block through a unique function
@@ -21,7 +53,9 @@ export function createHeatmapCodeBlock(
 	}
 
 	const trimmedSource = source.trim();
-	const query = parseQueryToJSEP(trimmedSource);
+	const { remainingLines, directoryFilter } =
+		extractDirectoryDirectives(trimmedSource);
+	const query = parseQueryToJSEP(remainingLines);
 
 	if (!query?.options) return; // add log / error
 
@@ -33,6 +67,7 @@ export function createHeatmapCodeBlock(
 			heatmapConfig: query?.options,
 			query: query?.filter,
 			isCodeBlock: true,
+			directoryFilter,
 		}),
 	);
 
@@ -59,7 +94,9 @@ export function createSlotsCodeBlock(
 	if (!state.plugin.data || !state.plugin.data.settings) {
 		return; // add log / error
 	}
-	const config = parseSlotQuery(source);
+	const { remainingLines, directoryFilter } =
+		extractDirectoryDirectives(source);
+	const config = parseSlotQuery(remainingLines);
 	if (config.length === 0) return; // add log / error
 
 	const container = el.createDiv("slots-codeblock");
@@ -69,6 +106,7 @@ export function createSlotsCodeBlock(
 		React.createElement(SlotWrapper, {
 			slots: config,
 			isCodeBlock: true,
+			directoryFilter,
 		}),
 	);
 

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -10,10 +10,13 @@ import {
 	getStartOfWeek,
 	getStartOfYear,
 } from "@/utils/dateUtils";
-import { sumTimeEntries } from "@/utils/utils";
+import { sumTimeEntries, filterActivitiesByDirectory } from "@/utils/utils";
 import { DailyActivity } from "./types";
 import { moment as _moment, debounce, Notice, Vault } from "obsidian";
 import { getFileWordAndCharCount } from "@/utils/utils";
+import { DirectoryFilter } from "../defs/types";
+
+const NO_DIRECTORY_FILTER: DirectoryFilter = { include: [], exclude: [] };
 
 const moment = _moment as unknown as typeof _moment.default;
 
@@ -33,11 +36,13 @@ export async function getActivtityForFile(date: string, filePath: string) {
 export async function getTotalValueByDate(
 	date: string,
 	unit: Unit,
+	directoryFilter: DirectoryFilter = NO_DIRECTORY_FILTER,
 ): Promise<number> {
-	const activities = await getDB()
-		.dailyActivity.where("date")
-		.equals(date)
-		.toArray();
+	const activities = filterActivitiesByDirectory(
+		await getDB().dailyActivity.where("date").equals(date).toArray(),
+		directoryFilter.include,
+		directoryFilter.exclude,
+	);
 
 	let value = activities.reduce((sum, activity) => {
 		return sum + sumTimeEntries(activity, unit, true);
@@ -50,11 +55,16 @@ export async function getTotalValueInDateRange(
 	startDate: string,
 	endDate: string,
 	unit: Unit,
+	directoryFilter: DirectoryFilter = NO_DIRECTORY_FILTER,
 ) {
-	const activities = await getDB()
-		.dailyActivity.where("date")
-		.between(startDate, endDate, true, true)
-		.toArray();
+	const activities = filterActivitiesByDirectory(
+		await getDB()
+			.dailyActivity.where("date")
+			.between(startDate, endDate, true, true)
+			.toArray(),
+		directoryFilter.include,
+		directoryFilter.exclude,
+	);
 
 	let value = activities.reduce((sum, activity) => {
 		return sum + sumTimeEntries(activity, unit, true);
@@ -165,8 +175,13 @@ export async function getActivitiesFromLast24Hours(): Promise<DailyActivity[]> {
 
 export async function getTotalValueFromLast24Hours(
 	unit: Unit,
+	directoryFilter: DirectoryFilter = NO_DIRECTORY_FILTER,
 ): Promise<number> {
-	const activities = await getActivitiesFromLast24Hours();
+	const activities = filterActivitiesByDirectory(
+		await getActivitiesFromLast24Hours(),
+		directoryFilter.include,
+		directoryFilter.exclude,
+	);
 	return sumLast24Hours(activities, unit);
 }
 
@@ -237,6 +252,7 @@ export async function getCurrentCount(
 	unit: Unit,
 	target: TargetCount,
 	calc?: CalculationType,
+	directoryFilter: DirectoryFilter = NO_DIRECTORY_FILTER,
 ): Promise<number> {
 	if (target === TargetCount.CURRENT_FILE) {
 		if (state.currentActivity) {
@@ -273,7 +289,7 @@ export async function getCurrentCount(
 			}
 
 		case TargetCount.CURRENT_DAY:
-			return await getTotalValueByDate(state.today, unit);
+			return await getTotalValueByDate(state.today, unit, directoryFilter);
 
 		case TargetCount.CURRENT_WEEK:
 			startDate = formatDate(getStartOfWeek(new Date()));
@@ -296,7 +312,7 @@ export async function getCurrentCount(
 			break;
 
 		case TargetCount.LAST_DAY:
-			return getTotalValueFromLast24Hours(unit);
+			return getTotalValueFromLast24Hours(unit, directoryFilter);
 			break;
 
 		case TargetCount.LAST_WEEK:
@@ -332,7 +348,12 @@ export async function getCurrentCount(
 			throw new Error("Unsupported target type");
 	}
 
-	const value = await getTotalValueInDateRange(startDate, state.today, unit);
+	const value = await getTotalValueInDateRange(
+		startDate,
+		state.today,
+		unit,
+		directoryFilter,
+	);
 	return calc === CalculationType.AVG ? Math.round(value / totalDays) : value;
 }
 

--- a/src/defs/types.ts
+++ b/src/defs/types.ts
@@ -63,6 +63,16 @@ export enum HeatmapColorModes {
 	LIQUID = "liquid",
 }
 
+export interface DirectoryFilterSettings {
+	include: string;
+	exclude: string;
+}
+
+export interface DirectoryFilter {
+	include: string[];
+	exclude: string[];
+}
+
 export interface Settings {
 	dailyWritingGoal: number; // created as setting, not used anywhere yet
 	enabledLanguages: Language[]; // guides the definition of REGEXes for word counting
@@ -84,6 +94,7 @@ export interface Settings {
 			showEntries: boolean;
 		};
 		slots: SlotConfig[];
+		directoryFilters: DirectoryFilterSettings;
 	};
 }
 
@@ -176,6 +187,10 @@ export const DEFAULT_SETTINGS: Settings = {
 			showSlots: true,
 			showEntries: true,
 			showHeatmap: true,
+		},
+		directoryFilters: {
+			include: "",
+			exclude: "",
 		},
 		slots: [
 			{

--- a/src/ui/components/DirectoryFilterInfo.tsx
+++ b/src/ui/components/DirectoryFilterInfo.tsx
@@ -5,7 +5,7 @@ interface DirectoryFilterInfoProps {
   directoryFilter: DirectoryFilter;
 }
 
-const MAX_VALUE_LENGTH = 500;
+const MAX_VALUE_LENGTH = 100;
 
 const formatDirectoryList = (directories: string[]): string => {
   const joined = directories.join(", ");
@@ -24,9 +24,12 @@ export const DirectoryFilterInfo = ({
 
   return (
     <div className="directoryFilterInfo">
+      {include.length > 0 || exclude.length > 0 ? (
+        <div className="directoryFilterInfo__header">Directory Filter</div>
+      ) : null}
       {include.length > 0 && (
         <div className="directoryFilterInfo__row">
-          <span className="directoryFilterInfo__label">Include</span>
+          <span className="directoryFilterInfo__label">Include:</span>
           <span className="directoryFilterInfo__value">
             {formatDirectoryList(include)}
           </span>
@@ -34,7 +37,7 @@ export const DirectoryFilterInfo = ({
       )}
       {exclude.length > 0 && (
         <div className="directoryFilterInfo__row">
-          <span className="directoryFilterInfo__label">Exclude</span>
+          <span className="directoryFilterInfo__label">Exclude:</span>
           <span className="directoryFilterInfo__value">
             {formatDirectoryList(exclude)}
           </span>

--- a/src/ui/components/DirectoryFilterInfo.tsx
+++ b/src/ui/components/DirectoryFilterInfo.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import type { DirectoryFilter } from "@/defs/types";
+
+interface DirectoryFilterInfoProps {
+  directoryFilter: DirectoryFilter;
+}
+
+const MAX_VALUE_LENGTH = 500;
+
+const formatDirectoryList = (directories: string[]): string => {
+  const joined = directories.join(", ");
+  if (joined.length <= MAX_VALUE_LENGTH) return joined;
+  return joined.slice(0, MAX_VALUE_LENGTH).trimEnd() + "...";
+};
+
+export const DirectoryFilterInfo = ({
+  directoryFilter,
+}: DirectoryFilterInfoProps) => {
+  const { include, exclude } = directoryFilter;
+
+  if (include.length === 0 && exclude.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="directoryFilterInfo">
+      {include.length > 0 && (
+        <div className="directoryFilterInfo__row">
+          <span className="directoryFilterInfo__label">Include</span>
+          <span className="directoryFilterInfo__value">
+            {formatDirectoryList(include)}
+          </span>
+        </div>
+      )}
+      {exclude.length > 0 && (
+        <div className="directoryFilterInfo__row">
+          <span className="directoryFilterInfo__label">Exclude</span>
+          <span className="directoryFilterInfo__value">
+            {formatDirectoryList(exclude)}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/ui/components/Entries.tsx
+++ b/src/ui/components/Entries.tsx
@@ -5,10 +5,14 @@ import React from "react";
 import { useEffect, useState, useRef } from "react";
 import { formatDate } from "../../utils/dateUtils";
 import { getActivityByDate } from "../../db/queries";
-import { sumTimeEntries, getFileNameWithoutExtension } from "../../utils/utils";
+import {
+  sumTimeEntries,
+  getFileNameWithoutExtension,
+  filterActivitiesByDirectory,
+} from "../../utils/utils";
 import { state, EVENTS } from "../../core/pluginState";
 import { DailyActivity } from "../../db/types";
-import { Unit } from "../../defs/types";
+import { DirectoryFilter, Unit } from "../../defs/types";
 import { FileView, Notice, setIcon } from "obsidian";
 import { ManualEntryModal } from "../components/ManualEntry";
 import { EntryFilter } from "@/core/codeBlocks";
@@ -16,11 +20,13 @@ import { EntryFilter } from "@/core/codeBlocks";
 interface EntriesProps {
   date?: string;
   filters?: EntryFilter[];
+  directoryFilter?: DirectoryFilter;
 }
 
 export const Entries = ({
   date = formatDate(new Date()),
   filters,
+  directoryFilter,
 }: EntriesProps) => {
   const [unit, setUnit] = useState<Unit>(Unit.WORD);
   const [entries, setEntries] = useState<DailyActivity[]>([]);
@@ -49,7 +55,11 @@ export const Entries = ({
     }
 
     setEntries(
-      fetchedActivities
+      filterActivitiesByDirectory(
+        fetchedActivities,
+        directoryFilter?.include ?? [],
+        directoryFilter?.exclude ?? [],
+      )
         .filter((entry) => sumTimeEntries(entry, Unit.WORD, true) != 0)
         .filter((entry) => {
           if (!filters || filters.length === 0) return true;
@@ -83,7 +93,7 @@ export const Entries = ({
     return () => {
       state.off(EVENTS.REFRESH_EVERYTHING, handleEntriesRefresh);
     };
-  }, []);
+  }, [directoryFilter]);
 
   return (
     <div className="todayEntries__section">

--- a/src/ui/components/Heatmap.tsx
+++ b/src/ui/components/Heatmap.tsx
@@ -3,10 +3,19 @@ import { useLiveQuery } from "dexie-react-hooks";
 import * as RadixTooltip from "@radix-ui/react-tooltip";
 import { moment as _moment } from "obsidian";
 import { weekdaysNames, monthNames } from "../texts";
-import { getDateForCell, sumTimeEntries } from "@/utils/utils";
+import {
+	getDateForCell,
+	sumTimeEntries,
+	filterActivitiesByDirectory,
+} from "@/utils/utils";
 import { formatDate } from "@/utils/dateUtils";
 import { DailyActivity } from "@/db/types";
-import { Unit, HeatmapColorModes, HeatmapConfig } from "@/defs/types";
+import {
+	Unit,
+	HeatmapColorModes,
+	HeatmapConfig,
+	DirectoryFilter,
+} from "@/defs/types";
 import { HeatmapCell } from "./HeatmapCell";
 import { compileEvaluator } from "@/core/codeBlockQuery";
 import { getDB } from "@/db/db";
@@ -15,12 +24,14 @@ interface HeatmapProps {
 	heatmapConfig: HeatmapConfig;
 	query?: any;
 	isCodeBlock?: boolean;
+	directoryFilter?: DirectoryFilter;
 }
 
 export const Heatmap = ({
 	heatmapConfig,
 	query,
 	isCodeBlock,
+	directoryFilter,
 }: HeatmapProps) => {
 	let startDate: Date | null = null;
 	let endDate: Date | null = null;
@@ -87,6 +98,12 @@ export const Heatmap = ({
 				.toArray();
 		}
 
+		results = filterActivitiesByDirectory(
+			results,
+			directoryFilter?.include ?? [],
+			directoryFilter?.exclude ?? [],
+		);
+
 		const dateMap: Record<string, number> = {};
 
 		for (const entry of results) {
@@ -96,7 +113,13 @@ export const Heatmap = ({
 		}
 
 		return dateMap;
-	});
+	}, [
+		weeksToShow,
+		baseDate?.getTime(),
+		JSON.stringify(query),
+		(directoryFilter?.include ?? []).join(","),
+		(directoryFilter?.exclude ?? []).join(","),
+	]);
 
 	if (!heatmapData) {
 		return <div className="heatmap-loading">Loading heatmap...</div>; // Replace with spinner or skeleton

--- a/src/ui/components/SidebarView.tsx
+++ b/src/ui/components/SidebarView.tsx
@@ -1,11 +1,13 @@
 import { KeyProvider } from "@/utils/useModiferKey";
 import React, { useEffect, useState } from "react";
-import type { PluginData } from "@/defs/types";
+import type { DirectoryFilter, PluginData } from "@/defs/types";
 import KeepTheRhythm from "@/main";
 import { Heatmap } from "./Heatmap";
 import { SlotWrapper } from "./SlotWrapper";
 import { EVENTS, state } from "@/core/pluginState";
 import { Entries } from "./Entries";
+import { getSidebarDirectoryFilter } from "@/utils/utils";
+import { DirectoryFilterInfo } from "./DirectoryFilterInfo";
 
 interface KTRView {
   data?: PluginData;
@@ -30,6 +32,9 @@ export const KTRView = ({ plugin }: KTRView) => {
   const [showSlots, setShowSlots] = useState(
     plugin.data.settings.sidebarConfig.visibility.showSlots,
   );
+  const [directoryFilter, setDirectoryFilter] = useState<DirectoryFilter>(
+    () => getSidebarDirectoryFilter(),
+  );
 
   const updateData = () => {
     setHeatmapConfigState(plugin.data.settings.heatmapConfig);
@@ -39,6 +44,7 @@ export const KTRView = ({ plugin }: KTRView) => {
     setShowHeatmap(plugin.data.settings.sidebarConfig.visibility.showHeatmap);
     setShowEntries(plugin.data.settings.sidebarConfig.visibility.showEntries);
     setShowSlots(plugin.data.settings.sidebarConfig.visibility.showSlots);
+    setDirectoryFilter(getSidebarDirectoryFilter());
   };
 
   useEffect(() => {
@@ -58,11 +64,18 @@ export const KTRView = ({ plugin }: KTRView) => {
 			`}
     >
       <KeyProvider>
-        {showSlots && <SlotWrapper slots={slots} />}
-        {showHeatmap && (
-          <Heatmap heatmapConfig={heatmapConfigState} query={""} />
+        <DirectoryFilterInfo directoryFilter={directoryFilter} />
+        {showSlots && (
+          <SlotWrapper slots={slots} directoryFilter={directoryFilter} />
         )}
-        {showEntries && <Entries />}
+        {showHeatmap && (
+          <Heatmap
+            heatmapConfig={heatmapConfigState}
+            query={""}
+            directoryFilter={directoryFilter}
+          />
+        )}
+        {showEntries && <Entries directoryFilter={directoryFilter} />}
       </KeyProvider>
     </div>
   );

--- a/src/ui/components/Slot.tsx
+++ b/src/ui/components/Slot.tsx
@@ -5,7 +5,7 @@ import { useState, useEffect, useRef } from "react";
 import * as RadixTooltip from "@radix-ui/react-tooltip";
 
 import { getCurrentCount } from "@/db/queries";
-import { CalculationType } from "@/defs/types";
+import { CalculationType, DirectoryFilter } from "@/defs/types";
 import { Tooltip } from "./Tooltip";
 import { getSlotLabel, weekdaysNames } from "../texts";
 import { TargetCount, SlotConfig, Unit } from "@/defs/types";
@@ -18,9 +18,11 @@ export const Slot = ({
 	calc,
 	onDelete,
 	isCodeBlock,
+	directoryFilter,
 }: SlotConfig & {
 	onDelete: (index: number) => void;
 	isCodeBlock?: boolean;
+	directoryFilter?: DirectoryFilter;
 }) => {
 	// TODO: should probably make something that stores data that's not from today so its only udpated on refresh everything!
 
@@ -121,7 +123,12 @@ export const Slot = ({
 		)
 			setIsLoading(true);
 		try {
-			const v = await getCurrentCount(unitType, optionType, calcMode);
+			const v = await getCurrentCount(
+				unitType,
+				optionType,
+				calcMode,
+				directoryFilter,
+			);
 			if (optionType === TargetCount.CURRENT_DAY) {
 				const newProgress =
 					(v / state.plugin.data.settings.dailyWritingGoal) * 100;
@@ -145,7 +152,7 @@ export const Slot = ({
 		return () => {
 			state.off(EVENTS.REFRESH_EVERYTHING, updateData);
 		};
-	}, [unitType, optionType, calcMode]);
+	}, [unitType, optionType, calcMode, directoryFilter]);
 
 	function isDayCompleted(dayIndex: number) {
 		const date = getDateBasedOnIndex(dayIndex);

--- a/src/ui/components/SlotWrapper.tsx
+++ b/src/ui/components/SlotWrapper.tsx
@@ -1,7 +1,13 @@
 import { Notice } from "obsidian";
 import { v4 as uuidv4 } from "uuid";
 import React from "react";
-import { CalculationType, SlotConfig, TargetCount, Unit } from "@/defs/types";
+import {
+	CalculationType,
+	DirectoryFilter,
+	SlotConfig,
+	TargetCount,
+	Unit,
+} from "@/defs/types";
 import { Slot } from "./Slot";
 import { state } from "@/core/pluginState";
 import { useEffect, useState, useRef } from "react";
@@ -10,9 +16,14 @@ import { TransitionGroup, CSSTransition } from "react-transition-group";
 interface SlotWrapperProps {
 	slots: SlotConfig[] | undefined;
 	isCodeBlock?: boolean;
+	directoryFilter?: DirectoryFilter;
 }
 
-export const SlotWrapper = ({ slots, isCodeBlock }: SlotWrapperProps) => {
+export const SlotWrapper = ({
+	slots,
+	isCodeBlock,
+	directoryFilter,
+}: SlotWrapperProps) => {
 	const [slotsState, setSlotsState] = useState<
 		(SlotConfig & { uuid?: string })[] | undefined
 	>(() => slots?.map((slot) => ({ ...slot, uuid: uuidv4() })));
@@ -122,6 +133,7 @@ export const SlotWrapper = ({ slots, isCodeBlock }: SlotWrapperProps) => {
 									calc={slot.calc}
 									onDelete={handleDeleteClick}
 									isCodeBlock={isCodeBlock}
+									directoryFilter={directoryFilter}
 								/>
 							</div>
 						</CSSTransition>

--- a/src/ui/settings/SettingSchema.ts
+++ b/src/ui/settings/SettingSchema.ts
@@ -1,6 +1,6 @@
 export interface SettingItem {
   key: string;
-  type: "toggle" | "number" | "dropdown" | "date" | "custom";
+  type: "toggle" | "number" | "text" | "dropdown" | "date" | "custom";
   title: string;
   description?: string;
   placeholder?: string;
@@ -131,6 +131,22 @@ export const SETTINGS_SCHEMA: SettingsSchema = {
           type: "toggle",
           title: "Show heatmap",
           description: "Displays a heatmap with historic writing data.",
+        },
+        {
+          key: "sidebarConfig.directoryFilters.include",
+          type: "text",
+          title: "Include Directories",
+          description:
+            'Comma-separated list of directories to scope the sidebar\'s heatmap, slots, and entries to (e.g. "journal, projects"). Use "*" as a wildcard within a folder name (e.g. "*journal" matches "journal" and "myjournal"). Leave empty to include everything. Does not affect ktr-heatmap/ktr-slots/ktr-entries code blocks embedded in notes.',
+          placeholder: "journal, projects",
+        },
+        {
+          key: "sidebarConfig.directoryFilters.exclude",
+          type: "text",
+          title: "Exclude Directories",
+          description:
+            "Comma-separated list of directories to exclude from the sidebar (same syntax as Include Directories). Takes priority over Include Directories.",
+          placeholder: "journal/drafts, archive",
         },
       ],
     },

--- a/src/ui/settings/SettingsTab.ts
+++ b/src/ui/settings/SettingsTab.ts
@@ -110,6 +110,19 @@ export class SettingsTab extends PluginSettingTab {
         );
         break;
 
+      case "text":
+        setting.addText((text) =>
+          text
+            .setPlaceholder(config.placeholder ?? "")
+            .setValue(String(currentValue ?? ""))
+            .onChange(async (value) => {
+              setByPath(this.settings, config.key, value);
+              await this.plugin.updateAndSaveEverything();
+              updateVisibility(config.key, value);
+            }),
+        );
+        break;
+
       case "dropdown":
         setting.addDropdown((dropdown) => {
           dropdown

--- a/src/ui/styles/directoryFilterInfo.scss
+++ b/src/ui/styles/directoryFilterInfo.scss
@@ -1,0 +1,23 @@
+.directoryFilterInfo {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	margin-bottom: 8px;
+	font-size: var(--font-smallest);
+}
+
+.directoryFilterInfo__row {
+	display: flex;
+	gap: 4px;
+	align-items: baseline;
+}
+
+.directoryFilterInfo__label {
+	flex-shrink: 0;
+	color: var(--text-faint);
+}
+
+.directoryFilterInfo__value {
+	color: var(--text-muted);
+	word-break: break-word;
+}

--- a/src/ui/styles/directoryFilterInfo.scss
+++ b/src/ui/styles/directoryFilterInfo.scss
@@ -1,15 +1,29 @@
 .directoryFilterInfo {
 	display: flex;
 	flex-direction: column;
-	gap: 2px;
+	gap: 4px;
+
+	width: 100%;
+	max-width: 100%;
+	padding: var(--size-4-2);
+	border-radius: var(--radius-m);
+
+	border: 1px solid var(--background-modifier-border);
+	background: var(--background-primary);
+
 	margin-bottom: 8px;
-	font-size: var(--font-smallest);
+}
+
+.directoryFilterInfo__header {
+	font-size: var(--font-ui-small);
+	color: var(--text-muted);
 }
 
 .directoryFilterInfo__row {
 	display: flex;
 	gap: 4px;
 	align-items: baseline;
+	font-size: var(--font-smaller);
 }
 
 .directoryFilterInfo__label {

--- a/src/ui/styles/styles.scss
+++ b/src/ui/styles/styles.scss
@@ -4,6 +4,7 @@
 @use "./slot" as *;
 @use "./entries" as *;
 @use "./settings" as *;
+@use "./directoryFilterInfo" as *;
 
 .sidebar-view {
 	container-type: inline-size;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,6 +1,7 @@
 import { state } from "@/core/pluginState";
 import { HeatmapColorModes } from "../defs/types";
 import { CalculationType, TargetCount } from "../defs/types";
+import { DirectoryFilter } from "../defs/types";
 import { DailyActivity } from "@/db/types";
 import { App } from "obsidian";
 import { Language } from "../defs/types";
@@ -204,6 +205,75 @@ export function parseToggles(query: string) {
 	if (hideEntries) toggles.showEntries = false;
 
 	return toggles;
+}
+
+export function parseDirectoryList(raw?: string): string[] {
+	if (!raw) return [];
+	return raw
+		.split(",")
+		.map((entry) => entry.trim())
+		.filter(Boolean);
+}
+
+function escapeRegexExceptStar(segment: string): string {
+	return segment.replace(/[.+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function compileDirectoryPattern(pattern: string): RegExp[] {
+	return pattern
+		.split("/")
+		.filter(Boolean)
+		.map(
+			(segment) =>
+				new RegExp(
+					`^${escapeRegexExceptStar(segment).replace(/\*/g, ".*")}$`,
+				),
+		);
+}
+
+export function matchesCompiledPattern(
+	pathSegments: string[],
+	patternRegexes: RegExp[],
+): boolean {
+	if (patternRegexes.length === 0) return false;
+	if (patternRegexes.length > pathSegments.length) return false;
+	return patternRegexes.every((regex, i) => regex.test(pathSegments[i]));
+}
+
+export function filterActivitiesByDirectory<T extends { filePath: string }>(
+	activities: T[],
+	include: string[],
+	exclude: string[],
+): T[] {
+	if (include.length === 0 && exclude.length === 0) return activities;
+
+	const includePatterns = include.map(compileDirectoryPattern);
+	const excludePatterns = exclude.map(compileDirectoryPattern);
+
+	return activities.filter((activity) => {
+		const segments = activity.filePath.split("/");
+
+		if (excludePatterns.some((p) => matchesCompiledPattern(segments, p))) {
+			return false;
+		}
+		if (
+			includePatterns.length > 0 &&
+			!includePatterns.some((p) => matchesCompiledPattern(segments, p))
+		) {
+			return false;
+		}
+		return true;
+	});
+}
+
+export function getSidebarDirectoryFilter(): DirectoryFilter {
+	const directoryFilters =
+		state.plugin.data.settings.sidebarConfig?.directoryFilters;
+
+	return {
+		include: parseDirectoryList(directoryFilters?.include),
+		exclude: parseDirectoryList(directoryFilters?.exclude),
+	};
 }
 
 export async function getFileWordAndCharCount(


### PR DESCRIPTION
## Summary

Adds optional directory scoping so the plugin can be limited to specific folders instead of always tracking the whole vault.

- New **Include Directories** / **Exclude Directories** settings under the Sidebar section, applied to the sidebar's heatmap, slots, and entries (`Exclude` takes priority over `Include`). Matching supports `*` as a wildcard within a folder segment and is case-sensitive.
- New `INCLUDE`/`EXCLUDE` directives for the `ktr-slots` and `ktr-heatmap` code blocks, using the same syntax, independent from the sidebar setting.
- New read-only **Directory Filter** card in the sidebar, shown above the heatmap/slots/entries, so the active Include/Exclude scope is always visible at a glance.
- Fixed a stale-data bug in the heatmap: `useLiveQuery` had no dependency array, so it never refetched when the query, directory filter, or week range changed after the initial render.
- Threaded the directory filter through `getCurrentCount`/`getTotalValueByDate`/`getTotalValueInDateRange`/`getTotalValueFromLast24Hours` in `src/db/queries.ts` so slot calculations respect it.
- Updated the README with the new settings, code block syntax, and a directory-matching reference table.

## UI

### Sidebar
<img width="272" height="557" alt="sidebar" src="https://github.com/user-attachments/assets/23ef1f55-9675-4bb6-a3eb-428cf063c504" />

### Settings
<img width="637" height="249" alt="settings" src="https://github.com/user-attachments/assets/4e31b762-4720-4aa0-aa3a-687400ce9077" />

## Test plan

- [ ] Set Include/Exclude Directories in settings and confirm the sidebar heatmap/slots/entries scope to the expected folders
- [ ] Confirm the new Directory Filter card in the sidebar reflects the active Include/Exclude values
- [ ] Add `INCLUDE`/`EXCLUDE` lines to a `ktr-slots` block and a `ktr-heatmap` block and confirm both filter correctly
- [ ] Edit a `ktr-heatmap` block's query/options and confirm it now refreshes without reloading the note
- [ ] Verify wildcard (`*`) matching and case-sensitivity behave as documented

## Comments from the author
Hello @benjaminezequiel , I'm using your plugin to write my novel, and I love it. I have a couple of ideas to improve it (using my experience), and currently I'm testing these changes with my writing workflow. 

I think this change/feature will cover the issues and feature requests:
* [Feature Request Exclude specific files/folders or support Regex](https://github.com/benjaminezequiel/keep-the-rhythm/issues/103)
* [Feature Request: path filtering for sidebar](https://github.com/benjaminezequiel/keep-the-rhythm/issues/85)
* [Excluded folders setting](https://github.com/benjaminezequiel/keep-the-rhythm/issues/31)

I added two new `INCLUDE` and `EXCLUDE` optional options without changing `filePath` to avoid conflicts with other workflows that other users can be using.

